### PR TITLE
Fix bg-image css of example

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -6,9 +6,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
   <style>
+    html,body{
+        min-height: 100%;
+    }
     body {
         background: url('bg.jpg');
         background-size:cover;
+        background-repeat: no-repeat;
     }
 
    .button--open {


### PR DESCRIPTION
画面サイズによって背景画像が美しく表示されないので、その修正です。
![_3_6_16__13_28](https://cloud.githubusercontent.com/assets/1548478/13552293/5834244e-e39f-11e5-8fc9-b1062ddc9f0f.png)
