### PR TITLE
Fix #19

### DIFF
--- a/example/src/example.js
+++ b/example/src/example.js
@@ -1,10 +1,16 @@
 import React, { Component } from 'react';
 import Modal from '../../src';
 
+const key = 'react-elastic-modal-example';
+
 export default class Example extends Component {
   constructor(props) {
     super(props);
-    this.state = { isOpen: false };
+    this.state = (JSON.parse(localStorage.getItem(key)) || { isOpen: false });
+  }
+
+  componentDidUpdate() {
+    localStorage.setItem(key, JSON.stringify(this.state));
   }
 
   render() {

--- a/src/index.js
+++ b/src/index.js
@@ -64,7 +64,15 @@ export default class ElasticModal extends Component {
 
   componentDidMount() {
     this.setMountState();
-    this.setDefaultState();
+    this.setDefaultState(() => {
+      if (!this.props.isOpen) {
+        return;
+      }
+
+      this.resize(() => {
+        this.open();
+      });
+    });
   }
 
   componentWillReceiveProps(next) {
@@ -79,7 +87,7 @@ export default class ElasticModal extends Component {
     }
   }
 
-  setDefaultState() {
+  setDefaultState(callback) {
     const width = this.refs.wrapper.clientWidth;
     const height = this.refs.wrapper.clientHeight;
     this.setState({
@@ -89,14 +97,14 @@ export default class ElasticModal extends Component {
       bottom: height * (0.5 + svgMarginRatio),
       right: width * (0.5 + svgMarginRatio),
       left: width * (0.5 + svgMarginRatio),
-    });
+    }, callback);
   }
 
   setMountState() {
     this.setState({ isMount: true });
   }
 
-  resize() {
+  resize(callback) {
     const { isOpen } = this.props;
     const width = this.refs.wrapper.clientWidth;
     const height = this.refs.wrapper.clientHeight;
@@ -107,7 +115,7 @@ export default class ElasticModal extends Component {
       bottom: isOpen ? height * (1 + svgMarginRatio) : height * (0.5 + svgMarginRatio),
       right: isOpen ? width * (1 + svgMarginRatio) : width * (0.5 + svgMarginRatio),
       left: isOpen ? width * svgMarginRatio : width * (0.5 + svgMarginRatio),
-    });
+    }, callback);
   }
 
   conponentWillUnmount() {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -579,4 +579,37 @@ describe('Modal test', () => {
       done();
     }, 1000);
   });
+
+  it('#19 should be open automatically if specify `<ElasticModal isOpen={true} />`', done => {
+    sinon.spy(Modal.prototype, 'componentDidMount');
+    sinon.spy(Modal.prototype, 'componentWillReceiveProps');
+    sinon.spy(Modal.prototype, 'open');
+
+    const wrapper = mount(
+      <Modal
+        isOpen
+        modal={{
+          backgroundColor: '#f5f5f5',
+          width: '199px',
+          height: '299px',
+          opacity: 0.8,
+          zIndex: 9999,
+        }}
+        overlay={{
+          background: 'rgba(1, 1, 1, 0.5)',
+          zIndex: 9998,
+        }}
+      >
+        test
+      </Modal>
+    );
+
+    setTimeout(() => {
+      assert(Modal.prototype.componentDidMount.calledOnce);
+      assert(Modal.prototype.open.calledOnce);
+      assert(wrapper.instance().isAnimationStop());
+
+      done();
+    }, 0);
+  });
 });


### PR DESCRIPTION
- fix: Draw the broken <pash> when run a `.open` immediately after `.componentDidMount`.

componentDidMount時に`isOpen`プロパティが`true`であれば、アニメーションを静止した状態でモーダルウィンドウを表示します。
`example`は開いた状態で画面をリロードすると、モーダルウィンドウを開いた状態にする変更です。

やや`src/index.js`の変更が荒削りなので、よりよいコードに修正を望みます。☆_✲ﾟ_｡(((´♡‿♡`+)))｡_ﾟ✲_☆
